### PR TITLE
fix pointer-type parameters.

### DIFF
--- a/lcache_test.go
+++ b/lcache_test.go
@@ -104,6 +104,28 @@ func TestEvictContainer(t *testing.T) {
 	}
 }
 
+type Foo struct {
+	A int
+	B string
+}
+
+func TestPointerValues(t *testing.T) {
+	fn := func(f *Foo) (interface{}, error) {
+		return nil, nil
+	}
+	c, _ := NewWithSize(2, fn, 300*time.Millisecond)
+
+	c.Get(new(Foo))
+	c.Get(new(Foo))
+	if c.Len() != 1 {
+		t.Errorf("container expected length is 1, but got %d", c.Len())
+	}
+	c.Remove(new(Foo))
+	if c.Len() != 0 {
+		t.Errorf("container expected length is 0, but got %d", c.Len())
+	}
+}
+
 func TestMust(t *testing.T) {
 	defer func() {
 		if p := recover(); p != nil {


### PR DESCRIPTION
In old version, the key of container is verbose output of the given
parameters. Pointer-type parameters are treated as different keys, it
will cause most waste of resources. To solve this, we could use the
original value with `reflect` help. And to avoid parameters dirty, we
use `#` as a division between parameters.